### PR TITLE
Move TestFlight Beta Deploy to self-hosted Runner

### DIFF
--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -31,6 +31,7 @@ jobs:
       googleserviceinfoplistpath: 'OwnYourData/Supporting Files/GoogleService-Info.plist'
       setupsigning: true
       fastlanelane: beta
+      runsonlabels: '["macOS", "self-hosted"]'
     secrets: inherit
   deployfirebase:
     name: Deploy Firebase Project


### PR DESCRIPTION
# Move TestFlight Beta Deploy to self-hosted Runner

## :recycle: Current situation & Problem
As the GitHub public runner XCode `latest-stable` version still points to 15.4, the TestFlight deployment workflow fails with new keywords such as `@retroactive`. Therefore, we'll move this workflow to our self-hosted runners


## :gear: Release Notes 
- Move TestFlight Beta Deploy to self-hosted Runner


## :books: Documentation
--


## :white_check_mark: Testing
--


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
